### PR TITLE
Fix links in all README.md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A curated list of awesome Python frameworks, libraries, software, resources, cod
 - [Games](#games)
 - [Pygame](#pygame)
 
-## Games [⤴](README.md)
+## Games [⤴](/)
 - [Game of Life](estvrtecky/GameOfLife)
 - [Pong](estvrtecky/pong)
 - [Sokoban](estvrtecky/sokoban)
 
-## Pygame [⤴](README.md)
+## Pygame [⤴](/)
 - [Code Snippets](pygame/README.md/#code-snippets)

--- a/pygame/README.md
+++ b/pygame/README.md
@@ -3,7 +3,7 @@
 ### Table of Contents
 - [Code Snippets](#code-snippets)
 
-## Code Snippets [⤴](README.md)
+## Code Snippets [⤴](/pygame)
 - **[Label](label.py)** - Display text on the screen.
 
-back to [Awesome Python](../README.md)
+back to [Awesome Python](../)


### PR DESCRIPTION
Edit links in all `README.md` files to redirect users to the folder and not the `README.md` file.